### PR TITLE
Fix input

### DIFF
--- a/components/forms/email-form.js
+++ b/components/forms/email-form.js
@@ -45,15 +45,12 @@ const EmailForm = ({email, setEmail, step, setStep, setErrorMessage, errorMessag
                                 setErrorMessage('');
                                 setEmail(e.target.value);
                             }}
-                            required
                             className={'my-4 p-1 rounded w-full text-gray-900 w-full mt-10'}
                             ref={textInput}
                             autoComplete={'off'}
                             onFocus={() => setIsFocused(true)}
                             onBlur={() => setIsFocused(false)}
                             onKeyDown={(e) => {
-                                e.preventDefault();
-
                                 if (e.key === 'Enter') {
                                     handleNext();
                                 }


### PR DESCRIPTION
Input was broken after adding `onKeyDown` handler to email input. This PR fixes that as well as removes the `required` attribute since I'm doing custom validation.